### PR TITLE
adding .shader and .hlsl files overrides at gitattributes into c#

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -52,3 +52,6 @@
 *.prefab linguist-generated
 *.unity linguist-generated
 *.aar filter=lfs diff=lfs merge=lfs -text
+# Github linguist overrides into C#
+*.shader linguist-language=C#
+*.hlsl linguist-language=C#


### PR DESCRIPTION
adding .shader and .hlsl files overrides at gitattributes into c#, this must fix github linguist detection for those extensions